### PR TITLE
fix: add src so linting collects src files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ SPLIT_BEFORE_DOT=True
 [tool:isort]
 line_length=120
 [tool:pytest]
-testpaths = tests
+testpaths = tests src
 norecursedirs = .env data maps
 show_capture = True
 minversion = 3.5


### PR DESCRIPTION
this should add src files to pytest-pylint and isort 